### PR TITLE
feat: add multiple subscription functionality

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -9,8 +9,8 @@ output "region" {
 }
 
 output "subscription" {
+  value       = { for key, value in google_pubsub_subscription.this : key => value }
   description = "The Pub/Sub subscription created by this module."
-  value       = google_pubsub_subscription.this
 }
 
 output "service_account_key" {

--- a/variables.tf
+++ b/variables.tf
@@ -112,3 +112,11 @@ variable "cloud_function_memory" {
   type        = number
   default     = 256
 }
+
+
+
+variable "pubsub_subscriptions" {
+  description = "Variable for creating multiple subscriptions for pubsub pollers to avoid missing data"
+  type        = map(any)
+  default     = null
+}


### PR DESCRIPTION
Created a pubsub_subscriptions variable to allow for multiple subscriptions to logging topic.

This allows content team to share a collection with individual pollers for each dev environment.

Otherwise first poller to poll subscription gets the lines available at that moment instead of all lines.

The variable defaults to the same value as it uses before this change so should be backwards compatible.