### PR TITLE
feat: add region variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ No modules.
 | <a name="input_pubsub_maximum_backoff"></a> [pubsub\_maximum\_backoff](#input\_pubsub\_maximum\_backoff) | Retry policy maximum backoff for the Pub/Sub subscription (https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions) | `string` | `"600s"` | no |
 | <a name="input_pubsub_message_retention_duration"></a> [pubsub\_message\_retention\_duration](#input\_pubsub\_message\_retention\_duration) | Message retention for the Pub/Sub subscription (https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions) | `string` | `"86400s"` | no |
 | <a name="input_pubsub_minimum_backoff"></a> [pubsub\_minimum\_backoff](#input\_pubsub\_minimum\_backoff) | Retry policy minimum backoff for the Pub/Sub subscription (https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions) | `string` | `"10s"` | no |
+| <a name="input_region"></a> [region](#input\_region) | GCP region to install resources in. If not set, the region of the google provider is used. | `string` | `""` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   project = data.google_client_config.this.project
-  region  = data.google_client_config.this.region
+  region  = var.region != "" ? var.region : data.google_client_config.this.region
 
   function_env_vars = {
     "NAME"       = var.name
@@ -21,6 +21,8 @@ resource "google_pubsub_topic" "this" {
   message_storage_policy {
     allowed_persistence_regions = [local.region]
   }
+
+  project = local.project
 }
 
 resource "google_pubsub_subscription" "this" {
@@ -121,6 +123,8 @@ resource "google_cloudfunctions_function" "export" {
   max_instances       = var.cloud_function_max_instances
   timeout             = var.cloud_function_timeout
   available_memory_mb = var.cloud_function_memory
+
+  region = local.region
 }
 
 resource "google_service_account" "cloud_scheduler" {
@@ -148,6 +152,8 @@ resource "google_cloud_scheduler_job" "this" {
       service_account_email = google_service_account.cloud_scheduler.email
     }
   }
+
+  region = local.region
 }
 
 resource "google_service_account" "poller" {
@@ -203,6 +209,8 @@ resource "google_cloudfunctions_function" "feed_management" {
   max_instances         = var.cloud_function_max_instances
   timeout               = var.cloud_function_timeout
   available_memory_mb   = var.cloud_function_memory
+
+  region = local.region
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,12 @@ variable "name" {
   }
 }
 
+variable "region" {
+  type        = string
+  description = "GCP region to install resources in. If not set, the region of the google provider is used."
+  default     = ""
+}
+
 variable "labels" {
   description = <<-EOF
     A map of labels to add to resources (https://cloud.google.com/resource-manager/docs/creating-managing-labels)"


### PR DESCRIPTION
This change adds the region variable. The region variable is needed
to support GCP Solution Catalog, a UI-based way that can deploy
terraform modules