### PR TITLE
feat: add ability to export projects

### DIFF
--- a/cloudfunctions/main.go
+++ b/cloudfunctions/main.go
@@ -217,11 +217,17 @@ func publishProjects(projResponse *cloudresourcemanager.ListProjectsResponse, ct
 		projLine, _ := project.MarshalJSON()
 		fmt.Println(string(projLine))
 
+		collecting := "false"
+		if projectID == project.ProjectId {
+			collecting = "true"
+		}
+
 		pubResult := topic.Publish(ctx, &pubsub.Message{
 			Data: []byte(projLine),
 			Attributes: map[string]string{
 				"snapshotTime": strconv.FormatInt(snapshotTime.UnixNano(), 10),
 				"data_type":    "cloudresourcemanager.Project",
+				"collecting":   collecting,
 			},
 		})
 


### PR DESCRIPTION
We need project information to feed same as asset info on a regular basis so we can create project resource that doesn't require valid from field to be set for months or years