### PR TITLE
chore: add changelog and pre-commit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @luke-zhu @arthur-observe @stefandorsett
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+## What seems broken?
+
+Please describe the problem as clearly as you can, ideally with links to 
+screenshots or other useful references.
+
+## What does the correct behavior look like?
+
+Please describe the ideal state as clearly as you can, ideally with links
+to examples or screenshots or other useful references. 
+
+## How badly is this break impacting you? How would fixing it be valuable for you?
+
+Any info you can provide here will help us prioritize it better. 
+
+## What kind of urgency / priority would you consider this?
+
+High, Medium, Low - And why? Any context you can add is super helpful. 
+
+## Any other notes to add?
+
+Optional -- remove this is it's not necessary.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+## What change would you like made?
+
+Please describe your desired change as clearly as you can, ideally with 
+links to examples or other useful references.
+
+## How would this change be valuable for you?
+
+Any info you can provide here will help us prioritize it better. 
+
+## What kind of priority would you consider this?
+
+High, Medium, Low - And why? Any context you can add is super helpful. 
+
+## Any other notes to add?
+
+Optional -- remove this is it's not necessary. 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## What does this PR do?
+
+Required - tell us about the great change you're submitting! It helps us know
+what we need to review and how to collaborate on making it better.
+
+## Motivation
+
+Optional - delete this section if it's already obvious
+
+## Limitations
+
+Optional - delete this section if it's not necessary
+
+## Testing
+
+Required - let us know what you've done for testing so far. It helps the 
+reviewer consider what more can be done to build confidence in the safety 
+of the change. 

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -1,0 +1,15 @@
+name: CI Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - $default-branch
+
+jobs:
+  commit-validation:
+    uses: observeinc/.github/.github/workflows/shared_commit-validation.yaml@main
+    secrets: inherit
+    with:
+      skip: '{}'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,8 @@
+name: Release and push
+on:
+  workflow_dispatch:
+
+jobs:
+  bump:
+    uses: observeinc/.github/.github/workflows/terraform_release.yaml@main
+    secrets: inherit


### PR DESCRIPTION
Looking at terraform-observe-jenkins it looks like we have a lot of the tools that we want for this terraform in our existing terraform-observe modules. We still want to do all of the linting and commit message checking, but there isn't value in attempting to test apply this in the same way. As this repo isn't based off of the template I'm not sure if there is value in attempting to update via dependabot. The changelog management and the release process seems worth keeping consistent (we're shipping everything to s3 already so in case customers can't use our terraform repository they can still use s3 to pull our terraform down)