### PR TITLE
feat: set function_max_instances default to 5

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -153,7 +153,7 @@ variable "function_timeout" {
 variable "function_max_instances" {
   description = "The limit on the maximum number of function instances that may coexist at a given time."
   type        = number
-  default     = null
+  default     = 5
 }
 
 variable "poller_roles" {


### PR DESCRIPTION
This makes it consistent with deployment manager.

