### PR TITLE
feat: use cloud function v0.2.0

### DIFF
--- a/function.tf
+++ b/function.tf
@@ -46,10 +46,11 @@ resource "google_cloudfunctions_function" "this" {
   service_account_email = google_service_account.cloudfunction[0].email
 
   runtime = "python310"
-  environment_variables = {
+  environment_variables = merge({
     "PARENT"   = var.resource
     "TOPIC_ID" = google_pubsub_topic.this.id
-  }
+    "VERSION"  = "${var.function_bucket}/${var.function_object}"
+  }, var.function_disable_logging ? { "DISABLE_LOGGING" : "ok" } : {})
 
   trigger_http     = true
   ingress_settings = "ALLOW_ALL" # Needed for Cloud Scheduler to work

--- a/variables.tf
+++ b/variables.tf
@@ -123,7 +123,7 @@ variable "function_bucket" {
 variable "function_object" {
   description = "GCS object key of the Cloud Function source code zip file"
   type        = string
-  default     = "google-cloud-functions-v0.1.0.zip"
+  default     = "google-cloud-functions-v0.2.0.zip"
 }
 
 variable "function_schedule" {
@@ -156,6 +156,12 @@ variable "function_max_instances" {
   default     = 5
 }
 
+variable "function_disable_logging" {
+  description = "Whether to disable function logging"
+  type        = bool
+  default     = false
+}
+
 variable "poller_roles" {
   description = <<-EOF
     A list of IAM roles to give the Observe poller (through the service account key output).
@@ -164,7 +170,5 @@ variable "poller_roles" {
 
   default = [
     "roles/monitoring.viewer",
-    "roles/cloudasset.viewer",
-    "roles/browser",
   ]
 }


### PR DESCRIPTION
## What does this PR do?

This change makes the terraform module use the v0.2.0 cloud function. It removes permissions from the poller for data that is collected by the cloud function.

This is part of https://observe.atlassian.net/browse/OB-13740

## Testing

I have applied the module, verified that the cloud function doesn't error, and verified that the new variable function_disable_logging works.
