### PR TITLE
fix: change function default memory to 512mb

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -139,7 +139,7 @@ variable "function_schedule" {
 variable "function_available_memory_mb" {
   description = "Memory (in MB), available to the function. Default value is 256. Possible values include 128, 256, 512, 1024, etc."
   type        = number
-  default     = 256
+  default     = 512
 }
 
 variable "function_timeout" {

--- a/variables.tf
+++ b/variables.tf
@@ -137,7 +137,7 @@ variable "function_schedule" {
 
 
 variable "function_available_memory_mb" {
-  description = "Memory (in MB), available to the function. Default value is 256. Possible values include 128, 256, 512, 1024, etc."
+  description = "Memory (in MB), available to the function. Default value is 512. Possible values include 128, 256, 512, 1024, etc."
   type        = number
   default     = 512
 }


### PR DESCRIPTION
## What does this PR do?
Ups default memory for function to 512mb - during testing 256 ran out

## Testing

Ran test code with 512