### PR TITLE
feat(asset-api): use the new Google cloud function that exercises the asset inventory api

### DIFF
--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -1,0 +1,6 @@
+module "observe_collection_example" {
+  source = "../../"
+
+  name   = var.name
+  resource = "projects/${var.project_id}"
+}

--- a/examples/basic_usage/provider.tf
+++ b/examples/basic_usage/provider.tf
@@ -1,0 +1,4 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/examples/basic_usage/terraform.tfvars
+++ b/examples/basic_usage/terraform.tfvars
@@ -1,0 +1,3 @@
+name   = "gcp-collecting"
+project_id = "project-id"
+region = "us-east-1"

--- a/examples/basic_usage/variables.tf
+++ b/examples/basic_usage/variables.tf
@@ -1,0 +1,14 @@
+variable "name" {
+  description = "The name of the observe collection"
+  type        = string
+}
+
+variable "project_id" {
+  description = "The project id to be observed"
+  type        = string
+}
+
+variable "region" {
+  type        = string
+  description = "GCP region"
+}

--- a/function.tf
+++ b/function.tf
@@ -163,10 +163,11 @@ resource "google_cloud_scheduler_job" "this" {
     http_method = "POST"
     uri         = google_cloudfunctions_function.this[0].https_trigger_url
 
-    body        = base64encode(jsonencode({
-      asset_types   = var.function_asset_types,
-      content_type  = var.function_content_types
-    }))
+    headers = {
+      Content-Type = "application/json"
+    }
+
+    body        = base64encode("{}")
 
     oidc_token {
       service_account_email = google_service_account.cloud_scheduler[0].email

--- a/function.tf
+++ b/function.tf
@@ -5,12 +5,6 @@ resource "google_service_account" "cloudfunction" {
   description = "Used by the Observe Cloud Functions"
 }
 
-resource "google_project_iam_member" "asset_service_account_permissions" {
-  project = data.google_project.this.project_id
-  role    = "roles/storage.objectAdmin"
-  member  = "serviceAccount:service-${data.google_project.this.number}@gcp-sa-cloudasset.iam.gserviceaccount.com"
-}
-
 resource "google_project_iam_member" "cloudfunction" {
   for_each = var.enable_function && local.resource_type == "projects" ? var.function_roles : toset([])
 
@@ -47,6 +41,8 @@ resource "google_pubsub_topic_iam_member" "cloudfunction_pubsub" {
 resource "google_storage_bucket" "this" {
   name     = "${var.name}-bucket"
   location = "US"
+
+  force_destroy = true
 }
 
 resource "google_storage_bucket_iam_member" "bucket_iam" {

--- a/function.tf
+++ b/function.tf
@@ -49,19 +49,6 @@ resource "google_storage_bucket" "this" {
   location = "US"
 }
 
-#resource "google_storage_notification" "bucket_notification" {
-#  bucket        = google_storage_bucket.this.name
-#  payload_format = "JSON_API_V1"
-#  event_types   = ["OBJECT_FINALIZE"]
-#  topic         = google_pubsub_topic.this.name
-#}
-
-#resource "google_pubsub_topic_iam_member" "topic" {
-#  topic  = google_pubsub_topic.this.name
-#  role   = "roles/pubsub.publisher"
-#  member = "serviceAccount:service-905791827358@gs-project-accounts.iam.gserviceaccount.com"
-#}
-
 resource "google_storage_bucket_iam_member" "bucket_iam" {
   bucket = google_storage_bucket.this.name
   role   = "roles/storage.objectCreator"

--- a/main.tf
+++ b/main.tf
@@ -77,7 +77,6 @@ resource "google_logging_folder_sink" "this" {
   }
 }
 
-
 resource "google_logging_organization_sink" "this" {
   count = local.resource_type == "organizations" ? 1 : 0
 
@@ -98,8 +97,6 @@ resource "google_logging_organization_sink" "this" {
     }
   }
 }
-
-
 
 resource "google_pubsub_topic_iam_member" "sink_pubsub" {
   topic  = google_pubsub_topic.this.name

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,3 @@
-# If updating this module, also update https://github.com/observeinc/deploymentmanager-google-collection
-# The 2 modules should contain same stuff.
-
 locals {
   resource_type = split("/", var.resource)[0]
   resource_id   = split("/", var.resource)[1]
@@ -15,7 +12,13 @@ locals {
   )
 }
 
-data "google_project" "this" {}
+data "google_project" "this" {
+  project_id = local.resource_type == "projects" ? local.resource_id : null
+}
+
+data "google_folder" "this" {
+  folder = local.resource_type == "folders" ? local.resource_id : null
+}
 
 resource "google_pubsub_topic" "this" {
   name   = var.name
@@ -38,7 +41,7 @@ resource "google_pubsub_subscription" "this" {
 resource "google_logging_project_sink" "this" {
   count       = local.resource_type == "projects" ? 1 : 0
   name        = var.name
-  project     = local.resource_id
+  project     = data.google_project.this.project_id
   destination = "pubsub.googleapis.com/${google_pubsub_topic.this.id}"
   filter      = var.logging_filter
 
@@ -59,7 +62,7 @@ resource "google_logging_folder_sink" "this" {
   count = local.resource_type == "folders" ? 1 : 0
 
   name             = var.name
-  folder           = local.resource_id
+  folder           = data.google_folder.this.folder_id
   destination      = "pubsub.googleapis.com/${google_pubsub_topic.this.id}"
   filter           = var.logging_filter
   include_children = var.folder_include_children

--- a/variables.tf
+++ b/variables.tf
@@ -106,7 +106,11 @@ variable "function_roles" {
     "roles/cloudasset.viewer",
     "roles/browser",
     "roles/logging.viewer",
-    "roles/monitoring.viewer" # for viewing projects
+    "roles/monitoring.viewer", # for viewing projects
+    "roles/storage.objectCreator",
+    "roles/storage.objectViewer",
+    "roles/storage.objectAdmin",
+    "roles/storage.admin"
   ]
 }
 
@@ -125,13 +129,13 @@ variable "folder_include_children" {
 variable "function_bucket" {
   description = "GCS bucket containing the Cloud Function source code"
   type        = string
-  default     = "observeinc"
+  default     = "observeinc-colin"
 }
 
 variable "function_object" {
   description = "GCS object key of the Cloud Function source code zip file"
   type        = string
-  default     = "google-cloud-functions-v0.2.0.zip"
+  default     = "google-cloud-functions-v0.3.0-alpha.3.zip"
 }
 
 variable "function_schedule" {
@@ -167,6 +171,30 @@ variable "function_disable_logging" {
   description = "Whether to disable function logging."
   type        = bool
   default     = false
+}
+
+variable "function_output_bucket" {
+  description = "The Google Cloud Storage (GCS) bucket where the function output will be stored."
+  type        = string
+  default     = "chutchinson-export-assets"
+}
+
+variable "function_content_types" {
+  description = "List of content types to export"
+  type        = list(string)
+  default     = ["RESOURCE", "IAM_POLICY"]
+}
+
+variable "function_schedule_frequency" {
+  description = "Cron schedule for the job"
+  type        = string
+  default     = "0 * * * *"
+}
+
+variable "function_asset_types" {
+  description = "List of asset types to export"
+  type        = list(string)
+  default     = ["storage.googleapis.com.*", "aiplatform.googleapis.com.*", "anthos.googleapis.com.*", "apigateway.googleapis.com.*", "apikeys.googleapis.com.*", "appengine.googleapis.com.*", "apps.k8s.io.*", "artifactregistry.googleapis.com.*", "assuredworkloads.googleapis.com.*", "batch.k8s.io.*", "beyondcorp.googleapis.com.*", "bigquery.googleapis.com.*", "bigquerymigration.googleapis.com.*", "bigtableadmin.googleapis.com.*", "cloudbilling.googleapis.com.*", "clouddeploy.googleapis.com.*", "cloudfunctions.googleapis.com.*", "cloudkms.googleapis.com.*", "cloudresourcemanager.googleapis.com.*", "composer.googleapis.com.*", "compute.googleapis.com.*", "connectors.googleapis.com.*", "container.googleapis.com.*", "containerregistry.googleapis.com.*", "dataflow.googleapis.com.*", "dataform.googleapis.com.*", "datafusion.googleapis.com.*", "datamigration.googleapis.com.*", "dataplex.googleapis.com.*", "dataproc.googleapis.com.*", "datastream.googleapis.com.*", "dialogflow.googleapis.com.*", "dlp.googleapis.com.*", "dns.googleapis.com.*", "documentai.googleapis.com.*", "domains.googleapis.com.*", "eventarc.googleapis.com.*", "extensions.k8s.io.*", "file.googleapis.com.*", "firestore.googleapis.com.*", "gameservices.googleapis.com.*", "gkebackup.googleapis.com.*", "gkehub.googleapis.com.*", "healthcare.googleapis.com.*", "iam.googleapis.com.*", "ids.googleapis.com.*", "k8s.io.*", "logging.googleapis.com.*", "managedidentities.googleapis.com.*", "memcache.googleapis.com.*", "metastore.googleapis.com.*", "monitoring.googleapis.com.*", "networkconnectivity.googleapis.com.*", "networking.k8s.io.*", "networkmanagement.googleapis.com.*", "networkservices.googleapis.com.*", "orgpolicy.googleapis.com.*", "osconfig.googleapis.com.*", "privateca.googleapis.com.*", "pubsub.googleapis.com.*", "rbac.authorization.k8s.io.*", "redis.googleapis.com.*", "run.googleapis.com.*", "secretmanager.googleapis.com.*", "servicedirectory.googleapis.com.*", "servicemanagement.googleapis.com.*", "serviceusage.googleapis.com.*", "spanner.googleapis.com.*", "speech.googleapis.com.*", "sqladmin.googleapis.com.*", "tpu.googleapis.com.*", "transcoder.googleapis.com.*", "vpcaccess.googleapis.com.*", "workflows.googleapis.com.*"]
 }
 
 variable "poller_roles" {

--- a/variables.tf
+++ b/variables.tf
@@ -135,7 +135,7 @@ variable "function_bucket" {
 variable "function_object" {
   description = "GCS object key of the Cloud Function source code zip file"
   type        = string
-  default     = "google-cloud-functions-v0.3.0-alpha.3.zip"
+  default     = "google-cloud-functions-v0.3.0-alpha.7.zip"
 }
 
 variable "function_schedule" {
@@ -179,22 +179,10 @@ variable "function_output_bucket" {
   default     = "chutchinson-export-assets"
 }
 
-variable "function_content_types" {
-  description = "List of content types to export"
-  type        = list(string)
-  default     = ["RESOURCE", "IAM_POLICY"]
-}
-
 variable "function_schedule_frequency" {
   description = "Cron schedule for the job"
   type        = string
   default     = "0 * * * *"
-}
-
-variable "function_asset_types" {
-  description = "List of asset types to export"
-  type        = list(string)
-  default     = ["storage.googleapis.com.*", "aiplatform.googleapis.com.*", "anthos.googleapis.com.*", "apigateway.googleapis.com.*", "apikeys.googleapis.com.*", "appengine.googleapis.com.*", "apps.k8s.io.*", "artifactregistry.googleapis.com.*", "assuredworkloads.googleapis.com.*", "batch.k8s.io.*", "beyondcorp.googleapis.com.*", "bigquery.googleapis.com.*", "bigquerymigration.googleapis.com.*", "bigtableadmin.googleapis.com.*", "cloudbilling.googleapis.com.*", "clouddeploy.googleapis.com.*", "cloudfunctions.googleapis.com.*", "cloudkms.googleapis.com.*", "cloudresourcemanager.googleapis.com.*", "composer.googleapis.com.*", "compute.googleapis.com.*", "connectors.googleapis.com.*", "container.googleapis.com.*", "containerregistry.googleapis.com.*", "dataflow.googleapis.com.*", "dataform.googleapis.com.*", "datafusion.googleapis.com.*", "datamigration.googleapis.com.*", "dataplex.googleapis.com.*", "dataproc.googleapis.com.*", "datastream.googleapis.com.*", "dialogflow.googleapis.com.*", "dlp.googleapis.com.*", "dns.googleapis.com.*", "documentai.googleapis.com.*", "domains.googleapis.com.*", "eventarc.googleapis.com.*", "extensions.k8s.io.*", "file.googleapis.com.*", "firestore.googleapis.com.*", "gameservices.googleapis.com.*", "gkebackup.googleapis.com.*", "gkehub.googleapis.com.*", "healthcare.googleapis.com.*", "iam.googleapis.com.*", "ids.googleapis.com.*", "k8s.io.*", "logging.googleapis.com.*", "managedidentities.googleapis.com.*", "memcache.googleapis.com.*", "metastore.googleapis.com.*", "monitoring.googleapis.com.*", "networkconnectivity.googleapis.com.*", "networking.k8s.io.*", "networkmanagement.googleapis.com.*", "networkservices.googleapis.com.*", "orgpolicy.googleapis.com.*", "osconfig.googleapis.com.*", "privateca.googleapis.com.*", "pubsub.googleapis.com.*", "rbac.authorization.k8s.io.*", "redis.googleapis.com.*", "run.googleapis.com.*", "secretmanager.googleapis.com.*", "servicedirectory.googleapis.com.*", "servicemanagement.googleapis.com.*", "serviceusage.googleapis.com.*", "spanner.googleapis.com.*", "speech.googleapis.com.*", "sqladmin.googleapis.com.*", "tpu.googleapis.com.*", "transcoder.googleapis.com.*", "vpcaccess.googleapis.com.*", "workflows.googleapis.com.*"]
 }
 
 variable "poller_roles" {


### PR DESCRIPTION
## What does this PR do?

This PR introduces significant changes to our existing Terraform configuration. It revolves around transitioning from using generic GCP APIs to using the asset inventory API for enhanced capabilities and performance.

## Motivation

Avoid the cloud function timeout and avoid the GCP API quota limits

## Testing

Tested locally with a new observe account and new GCP account
```
module "observe_gcp_collection" {
  source   = "github.com/observeinc/terraform-google-collection?ref=feat%2FOB-19512-export-and-feed"
  #source = "../../../google-collection/"
  name     = format(var.name_format, "env")
  resource = "projects/${var.project_id}"
}
```

refs: OB-19512
related: https://github.com/observeinc/google-cloud-functions/pull/11