### PR TITLE
chore(release-bucket): fix the release bucket to be the official observe bucket

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -129,13 +129,13 @@ variable "folder_include_children" {
 variable "function_bucket" {
   description = "GCS bucket containing the Cloud Function source code"
   type        = string
-  default     = "observeinc-colin"
+  default     = "observeinc"
 }
 
 variable "function_object" {
   description = "GCS object key of the Cloud Function source code zip file"
   type        = string
-  default     = "google-cloud-functions-v0.3.0-alpha.7.zip"
+  default     = "google-cloud-functions-v0.3.0-alpha.8.zip"
 }
 
 variable "function_schedule" {


### PR DESCRIPTION
## What does this PR do?

Did an alpha release of the GCS cloud function to the observe bucket instead of my personal bucket
