### PR TITLE
feat: add asset feed

### DIFF
--- a/asset.tf
+++ b/asset.tf
@@ -1,0 +1,37 @@
+
+# Create a feed that sends notifications about resource updates under a
+# particular folder.
+
+resource "google_cloud_asset_folder_feed" "folder_feed" {
+  count           = local.resource_type == "folders" ? 1 : 0
+  billing_project = var.project_id
+  folder          = data.google_folder.this[0].folder_id
+  feed_id         = "observe-asset-updates"
+  content_type    = "RESOURCE"
+
+  asset_types = ["aiplatform.googleapis.com.*", "anthos.googleapis.com.*", "apigateway.googleapis.com.*", "apikeys.googleapis.com.*", "appengine.googleapis.com.*", "apps.k8s.io.*", "artifactregistry.googleapis.com.*", "assuredworkloads.googleapis.com.*", "batch.k8s.io.*", "beyondcorp.googleapis.com.*", "bigquery.googleapis.com.*", "bigquerymigration.googleapis.com.*", "bigtableadmin.googleapis.com.*", "cloudbilling.googleapis.com.*", "clouddeploy.googleapis.com.*", "cloudfunctions.googleapis.com.*", "cloudkms.googleapis.com.*", "cloudresourcemanager.googleapis.com.*", "composer.googleapis.com.*", "compute.googleapis.com.*", "connectors.googleapis.com.*", "container.googleapis.com.*", "containerregistry.googleapis.com.*", "dataflow.googleapis.com.*", "dataform.googleapis.com.*", "datafusion.googleapis.com.*", "datamigration.googleapis.com.*", "dataplex.googleapis.com.*", "dataproc.googleapis.com.*", "datastream.googleapis.com.*", "dialogflow.googleapis.com.*", "dlp.googleapis.com.*", "dns.googleapis.com.*", "documentai.googleapis.com.*", "domains.googleapis.com.*", "eventarc.googleapis.com.*", "extensions.k8s.io.*", "file.googleapis.com.*", "firestore.googleapis.com.*", "gameservices.googleapis.com.*", "gkebackup.googleapis.com.*", "gkehub.googleapis.com.*", "healthcare.googleapis.com.*", "iam.googleapis.com.*", "ids.googleapis.com.*", "k8s.io.*", "logging.googleapis.com.*", "managedidentities.googleapis.com.*", "memcache.googleapis.com.*", "metastore.googleapis.com.*", "monitoring.googleapis.com.*", "networkconnectivity.googleapis.com.*", "networking.k8s.io.*", "networkmanagement.googleapis.com.*", "networkservices.googleapis.com.*", "orgpolicy.googleapis.com.*", "osconfig.googleapis.com.*", "privateca.googleapis.com.*", "pubsub.googleapis.com.*", "rbac.authorization.k8s.io.*", "redis.googleapis.com.*", "run.googleapis.com.*", "secretmanager.googleapis.com.*", "servicedirectory.googleapis.com.*", "servicemanagement.googleapis.com.*", "serviceusage.googleapis.com.*", "spanner.googleapis.com.*", "speech.googleapis.com.*", "sqladmin.googleapis.com.*", "storage.googleapis.com.*", "tpu.googleapis.com.*", "transcoder.googleapis.com.*", "vpcaccess.googleapis.com.*", "workflows.googleapis.com.*"]
+
+  feed_output_config {
+    pubsub_destination {
+      topic = google_pubsub_topic.this.id
+    }
+  }
+
+}
+
+
+# Create a feed that sends notifications about network resource updates.
+resource "google_cloud_asset_project_feed" "project_feed" {
+  count        = local.resource_type == "projects" ? 1 : 0
+  project      = var.project_id
+  feed_id      = "observe-asset-updates"
+  content_type = "RESOURCE"
+
+  asset_types = ["aiplatform.googleapis.com.*", "anthos.googleapis.com.*", "apigateway.googleapis.com.*", "apikeys.googleapis.com.*", "appengine.googleapis.com.*", "apps.k8s.io.*", "artifactregistry.googleapis.com.*", "assuredworkloads.googleapis.com.*", "batch.k8s.io.*", "beyondcorp.googleapis.com.*", "bigquery.googleapis.com.*", "bigquerymigration.googleapis.com.*", "bigtableadmin.googleapis.com.*", "cloudbilling.googleapis.com.*", "clouddeploy.googleapis.com.*", "cloudfunctions.googleapis.com.*", "cloudkms.googleapis.com.*", "cloudresourcemanager.googleapis.com.*", "composer.googleapis.com.*", "compute.googleapis.com.*", "connectors.googleapis.com.*", "container.googleapis.com.*", "containerregistry.googleapis.com.*", "dataflow.googleapis.com.*", "dataform.googleapis.com.*", "datafusion.googleapis.com.*", "datamigration.googleapis.com.*", "dataplex.googleapis.com.*", "dataproc.googleapis.com.*", "datastream.googleapis.com.*", "dialogflow.googleapis.com.*", "dlp.googleapis.com.*", "dns.googleapis.com.*", "documentai.googleapis.com.*", "domains.googleapis.com.*", "eventarc.googleapis.com.*", "extensions.k8s.io.*", "file.googleapis.com.*", "firestore.googleapis.com.*", "gameservices.googleapis.com.*", "gkebackup.googleapis.com.*", "gkehub.googleapis.com.*", "healthcare.googleapis.com.*", "iam.googleapis.com.*", "ids.googleapis.com.*", "k8s.io.*", "logging.googleapis.com.*", "managedidentities.googleapis.com.*", "memcache.googleapis.com.*", "metastore.googleapis.com.*", "monitoring.googleapis.com.*", "networkconnectivity.googleapis.com.*", "networking.k8s.io.*", "networkmanagement.googleapis.com.*", "networkservices.googleapis.com.*", "orgpolicy.googleapis.com.*", "osconfig.googleapis.com.*", "privateca.googleapis.com.*", "pubsub.googleapis.com.*", "rbac.authorization.k8s.io.*", "redis.googleapis.com.*", "run.googleapis.com.*", "secretmanager.googleapis.com.*", "servicedirectory.googleapis.com.*", "servicemanagement.googleapis.com.*", "serviceusage.googleapis.com.*", "spanner.googleapis.com.*", "speech.googleapis.com.*", "sqladmin.googleapis.com.*", "storage.googleapis.com.*", "tpu.googleapis.com.*", "transcoder.googleapis.com.*", "vpcaccess.googleapis.com.*", "workflows.googleapis.com.*"]
+
+  feed_output_config {
+    pubsub_destination {
+      topic = google_pubsub_topic.this.id
+    }
+  }
+}

--- a/examples/folder/example.auto.tfvars
+++ b/examples/folder/example.auto.tfvars
@@ -1,0 +1,3 @@
+name       = "FOLDER_NAME"
+resource   = "folders/<FOLDER_ID>"
+project_id = "PROJECT_ID"

--- a/examples/folder/example.auto.tfvars
+++ b/examples/folder/example.auto.tfvars
@@ -1,3 +1,0 @@
-name       = "FOLDER_NAME"
-resource   = "folders/<FOLDER_ID>"
-project_id = "PROJECT_ID"

--- a/examples/folder/main.tf
+++ b/examples/folder/main.tf
@@ -25,4 +25,5 @@ module "observe_gcp_collection" {
 
   name     = var.name
   resource = var.resource
+  project_id = var.project_id
 }

--- a/examples/folder/provider.tf
+++ b/examples/folder/provider.tf
@@ -1,4 +1,4 @@
 provider "google" {
-  project         = var.project_id
-  region          = var.region
+  project = var.project_id
+  region  = var.region
 }

--- a/variables.tf
+++ b/variables.tf
@@ -180,3 +180,9 @@ variable "poller_roles" {
     "roles/monitoring.viewer",
   ]
 }
+
+variable "project_id" {
+  description = "Billing Project ID needed for asset feed."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## What does this PR do?

Adds asset feed for folder or project level collection.  The asset feeds provides Observe with updates to changes in resources.

## Motivation

Incremental changes allow us to more quickly update the status of resources and handle a larger volume of resources and projects.

## Limitations

If using the folder level asset feed, you need to rerun the terraform when there are new projects to get them added.  Shut down projects also will need to have the terraform rerun to remove them from the project scope but things should continue to work if the shut down project is not removed.
