### PR TITLE
fix: add project id to bucket name to make unique

### DIFF
--- a/function.tf
+++ b/function.tf
@@ -39,7 +39,7 @@ resource "google_pubsub_topic_iam_member" "cloudfunction_pubsub" {
 }
 
 resource "google_storage_bucket" "this" {
-  name     = "${var.name}-bucket"
+  name     = "${var.name}-${var.project_id}-bucket"
   location = "US"
 
   force_destroy = true


### PR DESCRIPTION
## What does this PR do?

Adds project ID to the storage bucket name.

## Motivation

This makes the bucket name unique if you need to deploy to multiple projects.

## Testing

Tested by deploying to multiple projects in the same folder to see if we get any name collisions.