### PR TITLE
fix: bump max instances from 5 to 100 as a default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -155,7 +155,7 @@ variable "function_timeout" {
 variable "function_max_instances" {
   description = "The limit on the maximum number of function instances that may coexist at a given time."
   type        = number
-  default     = 5
+  default     = 100
 }
 
 variable "function_disable_logging" {


### PR DESCRIPTION
## What does this PR do?

Our sample infrastructure we test this on regularly hits the max number of instances when it is set to the current value of 5.  By default, GCP sets the max number of instances to 100 (https://cloud.google.com/functions/docs/configuring/max-instances) so we should just use that to make sure we don't hit the limit.

## Testing

Tested using our sample infrastructure and at 50 it easily is able to run.  Setting to 100 should be more than adequate for a more modest deployment.