### PR TITLE
fix(gcs): set a lifecycle rule as the cloud function no longer does deletion

### DIFF
--- a/function.tf
+++ b/function.tf
@@ -46,6 +46,15 @@ resource "google_storage_bucket" "this" {
   # Since the bucket is just a temporary storage for asset export objects until 
   # the function can process them, we want to implicitly delete any leftover objects
   # if Terraform plans to remove the bucket
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      age = 1
+    }
+  }
 }
 
 resource "google_storage_bucket_iam_member" "bucket_iam" {


### PR DESCRIPTION
## What does this PR do?

We're adjusting the GCP cloud function to not do the gcs delete so we're moving the deletion to infrastructure as code via a lifecycle rule

related: https://github.com/observeinc/google-cloud-functions/pull/30

![image](https://github.com/observeinc/terraform-google-collection/assets/131207535/567c23de-ac23-4479-856d-f11d7de85562)



## Motivation

Deleting the file in the cloud function sometimes proves over zealous

## Testing

Did a terraform plan && apply on my GCP project