### PR TITLE
fix: update cloudscheduler service account name

### DIFF
--- a/examples/project/main.tf
+++ b/examples/project/main.tf
@@ -2,7 +2,7 @@ module "observe_gcp_collection" {
   # source = "../../"
   source = "observeinc/collection/google"
 
-  name       = var.name
-  resource   = var.resource
+  name     = var.name
+  resource = var.resource
   project_id = var.project_id
 }

--- a/function.tf
+++ b/function.tf
@@ -62,7 +62,7 @@ resource "google_storage_bucket_iam_member" "bucket_iam" {
 resource "google_cloudfunctions_function" "this" {
   count = var.enable_function ? 1 : 0
 
-  name                  =  "${local.name}_assets_to_gcs"
+  name                  = "${local.name}_assets_to_gcs"
   description           = "Polls data from the Google Cloud API and sends to the Observe Pub/Sub topic."
   service_account_email = google_service_account.cloudfunction[0].email
 
@@ -97,7 +97,7 @@ resource "google_cloudfunctions_function" "this" {
 resource "google_cloudfunctions_function" "gcs_function" {
   count = var.enable_function ? 1 : 0
 
-  name                  =  "${local.name}_gcs_to_pubsub"
+  name                  = "${local.name}_gcs_to_pubsub"
   description           = "Triggered by changes in the Google Cloud Storage bucket and sends data to the Observe Pub/Sub topic."
   service_account_email = google_service_account.cloudfunction[0].email
 
@@ -138,7 +138,7 @@ resource "google_storage_bucket_iam_member" "gcs_function_bucket_iam" {
 resource "google_service_account" "cloud_scheduler" {
   count = var.enable_function ? 1 : 0
 
-  account_id  = "${local.name}-scheduler-observe"
+  account_id  = "${local.name}-scheduler"
   description = "Allows the Cloud Scheduler job to trigger a Cloud Function"
 }
 
@@ -174,7 +174,7 @@ resource "google_cloud_scheduler_job" "this" {
 resource "google_cloudfunctions_function" "rest_of_assets" {
   count = var.enable_function ? 1 : 0
 
-  name                  =  "${local.name}_observe_rest_of_assets"
+  name                  = "${local.name}_observe_rest_of_assets"
   description           = "Function that collections assets not capture by asset feed or asset exports."
   service_account_email = google_service_account.cloudfunction[0].email
 
@@ -207,7 +207,7 @@ resource "google_cloudfunctions_function" "rest_of_assets" {
 }
 
 resource "google_cloud_scheduler_job" "rest_of_assets" {
-  name        =  "${local.name}-more-assets-job"
+  name        = "${local.name}-more-assets-job"
   description = "Triggers the rest of assets Cloud Function"
   schedule    = var.function_schedule_frequency_rest_of_assets
 
@@ -236,7 +236,7 @@ resource "google_cloudfunctions_function_iam_member" "cloud_scheduler_rest_of_as
 }
 
 resource "google_cloud_tasks_queue" "task_queue" {
-  name     =  "${local.name}-${random_id.cloudtasks_queue.hex}"
+  name     = "${local.name}-${random_id.cloudtasks_queue.hex}"
   location = var.gcp_region
 
   rate_limits {

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "google_pubsub_topic" "this" {
 }
 
 resource "google_pubsub_subscription" "this" {
-  name   =  local.name
+  name   = local.name
   labels = var.labels
   topic  = google_pubsub_topic.this.name
 
@@ -44,7 +44,7 @@ resource "google_pubsub_subscription" "this" {
 
 resource "google_logging_project_sink" "this" {
   count       = local.resource_type == "projects" ? 1 : 0
-  name   = local.name
+  name        = local.name
   project     = data.google_project.this.project_id
   destination = "pubsub.googleapis.com/${google_pubsub_topic.this.id}"
   filter      = var.logging_filter
@@ -65,7 +65,7 @@ resource "google_logging_project_sink" "this" {
 resource "google_logging_folder_sink" "this" {
   count = local.resource_type == "folders" ? 1 : 0
 
-  name   = local.name
+  name             = local.name
   folder           = data.google_folder.this[0].folder_id
   destination      = "pubsub.googleapis.com/${google_pubsub_topic.this.id}"
   filter           = var.logging_filter
@@ -87,7 +87,7 @@ resource "google_logging_folder_sink" "this" {
 resource "google_logging_organization_sink" "this" {
   count = local.resource_type == "organizations" ? 1 : 0
 
-  name   = local.name
+  name        = local.name
   org_id      = local.resource_id
   destination = "pubsub.googleapis.com/${google_pubsub_topic.this.id}"
   filter      = var.logging_filter

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "name" {
   type        = string
   description = "Module name. Used as a name prefix."
-  default     = "observe-collection"
+  default     = "observe"
 
   validation {
     condition     = length(var.name) <= 20


### PR DESCRIPTION
## What does this PR do?

cloudscheduler service account had `observe` in it twice with the name format change causing it be too long.

## Testing

Tested using the examples
