### PR TITLE
feat: add sample TF to create service accounts

### DIFF
--- a/examples/folder/README.MD
+++ b/examples/folder/README.MD
@@ -1,0 +1,46 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.21 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | 4.77.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_observe_gcp_collection"></a> [observe\_gcp\_collection](#module\_observe\_gcp\_collection) | observeinc/collection/google | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_monitoring_monitored_project.primary](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_monitored_project) | resource |
+| [google_project.service_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
+| [google_projects.my_folder_projects](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/projects) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | Name for the Observe collection | `string` | `"observe"` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID to host resources | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The region where resources will be created | `string` | `"us-central1"` | no |
+| <a name="input_resource"></a> [resource](#input\_resource) | The identifier of the GCP Resource to monitor. The resource can be a project, folder, or organization. Examples: 'projects/my\_project-123', 'folders/1234567899', 'organizations/34739118321' | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_project_info"></a> [project\_info](#output\_project\_info) | n/a |
+| <a name="output_projects"></a> [projects](#output\_projects) | n/a |
+| <a name="output_service_account_private_key"></a> [service\_account\_private\_key](#output\_service\_account\_private\_key) | A service account key sent to the pollers for Pub/Sub and Cloud Monitoring |
+| <a name="output_subscription"></a> [subscription](#output\_subscription) | The Pub/Sub subscription created by this module. |
+<!-- END_TF_DOCS -->

--- a/examples/folder/folder.auto.tfvars
+++ b/examples/folder/folder.auto.tfvars
@@ -1,0 +1,2 @@
+resource="folders/0123456790"
+project_id = "scoping-project-0123456790"

--- a/examples/folder/main.tf
+++ b/examples/folder/main.tf
@@ -23,8 +23,8 @@ module "observe_gcp_collection" {
   # source = "../../"
   source = "observeinc/collection/google"
 
-  name       = var.name
-  resource   = var.resource
+  name     = var.name
+  resource = var.resource
 
   # scoping project
   # ref: https://cloud.google.com/monitoring/settings/multiple-projects

--- a/examples/project/README.MD
+++ b/examples/project/README.MD
@@ -1,0 +1,38 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.21 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 1 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_observe_gcp_collection"></a> [observe\_gcp\_collection](#module\_observe\_gcp\_collection) | observeinc/collection/google | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | Name for the Observe collection | `string` | `"observe"` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID to host resources | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The region where resources will be created | `string` | `"us-central1"` | no |
+| <a name="input_resource"></a> [resource](#input\_resource) | The identifier of the GCP Resource to monitor. The resource can be a project, folder, or organization. Examples: 'projects/my\_project-123', 'folders/1234567899', 'organizations/34739118321' | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_service_account_private_key"></a> [service\_account\_private\_key](#output\_service\_account\_private\_key) | A service account key sent to the pollers for Pub/Sub and Cloud Monitoring |
+| <a name="output_subscription"></a> [subscription](#output\_subscription) | The Pub/Sub subscription created by this module. |
+<!-- END_TF_DOCS -->

--- a/examples/project/project.auto.tfvars
+++ b/examples/project/project.auto.tfvars
@@ -1,0 +1,2 @@
+resource   = "projects/project"
+project_id = "project_id"

--- a/examples/service_account/README.MD
+++ b/examples/service_account/README.MD
@@ -1,0 +1,38 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | 4.78.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_folder_iam_member.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_project_iam_member.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_service_account.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_folder"></a> [folder](#input\_folder) | The folder ID to grant the IAM roles to service account in. | `string` | `null` | no |
+| <a name="input_folder_collection_roles"></a> [folder\_collection\_roles](#input\_folder\_collection\_roles) | A list of IAM roles to give to the service account for folder collection.  Note that permissions are broad and this account should only be used to set up collection intially and not for anything else. | `set(string)` | <pre>[<br>  "roles/browser",<br>  "roles/cloudasset.owner",<br>  "roles/cloudfunctions.admin",<br>  "roles/cloudscheduler.admin",<br>  "roles/cloudtasks.admin",<br>  "roles/iam.serviceAccountCreator",<br>  "roles/iam.serviceAccountDeleter",<br>  "roles/iam.serviceAccountKeyAdmin",<br>  "roles/iam.serviceAccountTokenCreator",<br>  "roles/iam.serviceAccountUser",<br>  "roles/logging.admin",<br>  "roles/monitoring.admin",<br>  "roles/pubsub.admin",<br>  "roles/resourcemanager.folderAdmin",<br>  "roles/resourcemanager.projectCreator",<br>  "roles/resourcemanager.projectDeleter",<br>  "roles/resourcemanager.projectMover",<br>  "roles/serviceusage.serviceUsageAdmin",<br>  "roles/serviceusage.serviceUsageConsumer",<br>  "roles/servicemanagement.admin",<br>  "roles/storage.admin"<br>]</pre> | no |
+| <a name="input_project"></a> [project](#input\_project) | The project ID to create the service account in.  For project collection, this will also assign the IAM roles to the account in the project. | `string` | n/a | yes |
+| <a name="input_project_collection_roles"></a> [project\_collection\_roles](#input\_project\_collection\_roles) | A list of IAM roles to give to the service account.  Note that permissions are broad and this account should only be used to set up collection intially and not for anything else. | `set(string)` | <pre>[<br>  "roles/browser",<br>  "roles/cloudasset.owner",<br>  "roles/cloudfunctions.admin",<br>  "roles/cloudscheduler.admin",<br>  "roles/cloudtasks.admin",<br>  "roles/iam.serviceAccountCreator",<br>  "roles/iam.serviceAccountDeleter",<br>  "roles/iam.serviceAccountKeyAdmin",<br>  "roles/iam.serviceAccountTokenCreator",<br>  "roles/iam.serviceAccountUser",<br>  "roles/logging.admin",<br>  "roles/monitoring.admin",<br>  "roles/pubsub.admin",<br>  "roles/resourcemanager.projectIamAdmin",<br>  "roles/serviceusage.serviceUsageAdmin",<br>  "roles/serviceusage.serviceUsageConsumer",<br>  "roles/servicemanagement.admin",<br>  "roles/storage.admin"<br>]</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_service_account"></a> [service\_account](#output\_service\_account) | n/a |
+<!-- END_TF_DOCS -->

--- a/examples/service_account/main.tf
+++ b/examples/service_account/main.tf
@@ -1,0 +1,22 @@
+resource "google_service_account" "this" {
+
+  account_id  = "observe-collect"
+  description = "Used to set up collection"
+  project     = var.project
+}
+
+resource "google_project_iam_member" "this" {
+  for_each = var.project_collection_roles
+
+  project = var.project
+  role    = each.key
+  member  = "serviceAccount:${google_service_account.this.email}"
+}
+
+resource "google_folder_iam_member" "this" {
+  for_each = var.folder_collection_roles
+
+  folder = var.folder
+  role    = each.key
+  member  = "serviceAccount:${google_service_account.this.email}"
+}

--- a/examples/service_account/main.tf
+++ b/examples/service_account/main.tf
@@ -5,18 +5,26 @@ resource "google_service_account" "this" {
   project     = var.project
 }
 
-resource "google_project_iam_member" "this" {
-  for_each = var.project_collection_roles
+###############
+#
+# Uncomment the first section for a service account that can deploy to a project
+# and uncomment the second section for folder collection.  If you are deploying to
+# a folder, you need to add the folder id to the service_account.auto.tfvars file as well.
+#
+################
 
-  project = var.project
-  role    = each.key
-  member  = "serviceAccount:${google_service_account.this.email}"
-}
+# resource "google_project_iam_member" "this" {
+#   for_each = var.project_collection_roles
 
-resource "google_folder_iam_member" "this" {
-  for_each = var.folder_collection_roles
+#   project = var.project
+#   role    = each.key
+#   member  = "serviceAccount:${google_service_account.this.email}"
+# }
 
-  folder = var.folder
-  role    = each.key
-  member  = "serviceAccount:${google_service_account.this.email}"
-}
+# resource "google_folder_iam_member" "this" {
+#   for_each = var.folder_collection_roles
+
+#   folder = var.folder
+#   role    = each.key
+#   member  = "serviceAccount:${google_service_account.this.email}"
+# }

--- a/examples/service_account/output.tf
+++ b/examples/service_account/output.tf
@@ -1,0 +1,3 @@
+output "service_account" {
+   value = google_service_account.this
+}

--- a/examples/service_account/service_account.auto.tfvars
+++ b/examples/service_account/service_account.auto.tfvars
@@ -1,0 +1,2 @@
+project = "my_project_id"
+# folder ="my_folder_id" #uncomment for folder collection

--- a/examples/service_account/variables.tf
+++ b/examples/service_account/variables.tf
@@ -1,0 +1,73 @@
+variable "project_collection_roles" {
+  description = <<-EOF
+    A list of IAM roles to give to the service account.  Note that permissions are broad and this account should only be used to set up collection intially and not for anything else.
+  EOF
+  type        = set(string)
+
+  default = [
+    "roles/browser",
+    "roles/cloudasset.owner",
+    "roles/cloudfunctions.admin",
+    "roles/cloudscheduler.admin",
+    "roles/cloudtasks.admin",
+    "roles/iam.serviceAccountCreator",
+    "roles/iam.serviceAccountDeleter",
+    "roles/iam.serviceAccountKeyAdmin",
+    "roles/iam.serviceAccountTokenCreator",
+    "roles/iam.serviceAccountUser",
+    "roles/logging.admin",
+    "roles/monitoring.admin",
+    "roles/pubsub.admin",
+    "roles/resourcemanager.projectIamAdmin",
+    "roles/serviceusage.serviceUsageAdmin",
+    "roles/serviceusage.serviceUsageConsumer",
+    "roles/servicemanagement.admin",
+    "roles/storage.admin",
+  ]
+}
+
+variable "folder_collection_roles" {
+  description = <<-EOF
+    A list of IAM roles to give to the service account for folder collection.  Note that permissions are broad and this account should only be used to set up collection intially and not for anything else.
+  EOF
+  type        = set(string)
+
+  default = [
+    "roles/browser",
+    "roles/cloudasset.owner",
+    "roles/cloudfunctions.admin",
+    "roles/cloudscheduler.admin",
+    "roles/cloudtasks.admin",
+    "roles/iam.serviceAccountCreator",
+    "roles/iam.serviceAccountDeleter",
+    "roles/iam.serviceAccountKeyAdmin",
+    "roles/iam.serviceAccountTokenCreator",
+    "roles/iam.serviceAccountUser",
+    "roles/logging.admin",
+    "roles/monitoring.admin",
+    "roles/pubsub.admin",
+    "roles/resourcemanager.folderAdmin",
+    "roles/resourcemanager.projectCreator",
+    "roles/resourcemanager.projectDeleter",
+    "roles/resourcemanager.projectMover",
+    "roles/serviceusage.serviceUsageAdmin",
+    "roles/serviceusage.serviceUsageConsumer",
+    "roles/servicemanagement.admin",
+    "roles/storage.admin",
+  ]
+}
+
+variable "project" {
+    type = string
+    description = <<-EOF
+    The project ID to create the service account in.  For project collection, this will also assign the IAM roles to the account in the project.
+    EOF
+}
+
+variable "folder" {
+    type = string
+    description = <<-EOF
+    The folder ID to grant the IAM roles to service account in.
+    EOF
+    default = null
+}


### PR DESCRIPTION
## What does this PR do?

Creates an example of creating the service account required to run the terraform for collection.

## Motivation

Life is hard, we should make life easier where we can.

## Testing

Tested on a folder and a project.