### PR TITLE
fix: bump max memory for functions

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -146,7 +146,7 @@ variable "function_object" {
 variable "function_available_memory_mb" {
   description = "Memory (in MB), available to the function. Default value is 512. Possible values include 128, 256, 512, 1024, etc."
   type        = number
-  default     = 512
+  default     = 2048
 }
 
 variable "function_timeout" {


### PR DESCRIPTION
## What does this PR do?

Increases max memory for functions.  At 512MB, our sample infra causes it to fail so we should bump it.