### PR TITLE
fix(limit): fix character limits refs: #FSH-46

### DIFF
--- a/function.tf
+++ b/function.tf
@@ -6,7 +6,7 @@ resource "random_id" "cloudtasks_queue" {
 resource "google_service_account" "cloudfunction" {
   count = var.enable_function ? 1 : 0
 
-  account_id  = "${local.name}-cloudfunctions"
+  account_id  = "${local.name}-func"
   description = "Used by the Observe Cloud Functions"
 }
 
@@ -138,7 +138,7 @@ resource "google_storage_bucket_iam_member" "gcs_function_bucket_iam" {
 resource "google_service_account" "cloud_scheduler" {
   count = var.enable_function ? 1 : 0
 
-  account_id  = "${local.name}-scheduler"
+  account_id  = "${local.name}-sched"
   description = "Allows the Cloud Scheduler job to trigger a Cloud Function"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -11,8 +11,8 @@ locals {
     )
   )
 
-  # inject "observe" into all of our named resources
-  name = var.name == "observe" ? var.name : "${var.name}-observe"
+  # inject "obs" into all of our named resources
+  name = var.name == "obs" ? var.name : "${var.name}-obs"
 }
 
 data "google_project" "this" {
@@ -112,7 +112,7 @@ resource "google_pubsub_topic_iam_member" "sink_pubsub" {
 }
 
 resource "google_service_account" "poller" {
-  account_id  = "${local.name}-poller"
+  account_id  = "${local.name}-poll"
   description = "A service account for the Observe Pub/Sub and Logging pollers"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "name" {
   type        = string
   description = "Module name. Used as a name prefix."
-  default     = "observe"
+  default     = "obs"
 
   validation {
     condition     = length(var.name) <= 20


### PR DESCRIPTION
## What does this PR do?

Adjust prefixes we apply to be shorter to fit within GCP character limit requirements.

```
╷
│ Error: "account_id" ("a1234567890123456789-observe-cloudfunctions") doesn't match regexp "^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])$"
│ 
│   with module.observe_gcp_collection.google_service_account.cloudfunction[0],
│   on .terraform/modules/observe_gcp_collection/function.tf line 9, in resource "google_service_account" "cloudfunction":
│    9:   account_id  = "${local.name}-cloudfunctions"
│ 
╵
╷
│ Error: "account_id" ("a1234567890123456789-observe-scheduler") doesn't match regexp "^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])$"
│ 
│   with module.observe_gcp_collection.google_service_account.cloud_scheduler[0],
│   on .terraform/modules/observe_gcp_collection/function.tf line 141, in resource "google_service_account" "cloud_scheduler":
│  141:   account_id  = "${local.name}-scheduler"
│ 
╵
╷
│ Error: "account_id" ("a1234567890123456789-observe-poller") doesn't match regexp "^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])$"
│ 
│   with module.observe_gcp_collection.google_service_account.poller,
│   on .terraform/modules/observe_gcp_collection/main.tf line 115, in resource "google_service_account" "poller":
│  115:   account_id  = "${local.name}-poller"
```

## Testing

Tested by using the `examples/project` and setting a name of `a1234567890123456789`
