### PR TITLE
fix: bump function max memory default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -146,7 +146,7 @@ variable "function_object" {
 variable "function_available_memory_mb" {
   description = "Memory (in MB), available to the function. Default value is 512. Possible values include 128, 256, 512, 1024, etc."
   type        = number
-  default     = 2048
+  default     = 4096
 }
 
 variable "function_timeout" {

--- a/variables.tf
+++ b/variables.tf
@@ -146,7 +146,7 @@ variable "function_object" {
 variable "function_available_memory_mb" {
   description = "Memory (in MB), available to the function. Default value is 512. Possible values include 128, 256, 512, 1024, etc."
   type        = number
-  default     = 512
+  default     = 2048
 }
 
 variable "function_timeout" {


### PR DESCRIPTION
## What does this PR do?

Bumps max memory for functions to 4096 as we were running out of memory on our sample infra.

## Testing

Tested in our GCP tenant.