### PR TITLE
chore: add and update examples

### DIFF
--- a/examples/api/README.MD
+++ b/examples/api/README.MD
@@ -1,0 +1,32 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | 6.8.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_project_service.enabled_services](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_project"></a> [project](#input\_project) | The project ID to create the service account in.  For project collection, this will also assign the IAM roles to the account in the project. | `string` | n/a | yes |
+| <a name="input_services"></a> [services](#input\_services) | The list of APIs to enable for observe collection | `set(string)` | <pre>[<br>  "cloudasset.googleapis.com",<br>  "iam.googleapis.com",<br>  "logging.googleapis.com",<br>  "monitoring.googleapis.com",<br>  "pubsub.googleapis.com",<br>  "cloudresourcemanager.googleapis.com",<br>  "cloudfunctions.googleapis.com",<br>  "cloudbuild.googleapis.com",<br>  "cloudscheduler.googleapis.com",<br>  "storage.googleapis.com",<br>  "sqladmin.googleapis.com",<br>  "compute.googleapis.com",<br>  "serviceusage.googleapis.com",<br>  "container.googleapis.com",<br>  "redis.googleapis.com",<br>  "run.googleapis.com",<br>  "cloudtasks.googleapis.com"<br>]</pre> | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/examples/api/api.auto.tfvars
+++ b/examples/api/api.auto.tfvars
@@ -1,1 +1,1 @@
-project = "test-svc-account-automation"
+project = "my_project_id"

--- a/examples/api/api.auto.tfvars
+++ b/examples/api/api.auto.tfvars
@@ -1,0 +1,1 @@
+project = "test-svc-account-automation"

--- a/examples/api/main.tf
+++ b/examples/api/main.tf
@@ -1,0 +1,7 @@
+
+resource "google_project_service" "enabled_services" {
+  for_each = var.services  
+  
+  project = var.project
+  service = each.key
+}

--- a/examples/api/main.tf
+++ b/examples/api/main.tf
@@ -1,7 +1,7 @@
 
 resource "google_project_service" "enabled_services" {
-  for_each = var.services  
-  
+  for_each = var.services
+
   project = var.project
   service = each.key
 }

--- a/examples/api/variables.tf
+++ b/examples/api/variables.tf
@@ -1,14 +1,12 @@
 
 variable "project" {
-    type = string
-    description = <<-EOF
-    The project ID to create the service account in.  For project collection, this will also assign the IAM roles to the account in the project.
-    EOF
+  type        = string
+  description = "The project ID where apis will be enabled"
 }
 
 variable "services" {
   description = "The list of APIs to enable for observe collection"
-  type = set(string)
+  type        = set(string)
   default = [
     "cloudasset.googleapis.com",
     "iam.googleapis.com",

--- a/examples/api/variables.tf
+++ b/examples/api/variables.tf
@@ -1,0 +1,31 @@
+
+variable "project" {
+    type = string
+    description = <<-EOF
+    The project ID to create the service account in.  For project collection, this will also assign the IAM roles to the account in the project.
+    EOF
+}
+
+variable "services" {
+  description = "The list of APIs to enable for observe collection"
+  type = set(string)
+  default = [
+    "cloudasset.googleapis.com",
+    "iam.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com",
+    "pubsub.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "cloudfunctions.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "cloudscheduler.googleapis.com",
+    "storage.googleapis.com",
+    "sqladmin.googleapis.com",
+    "compute.googleapis.com",
+    "serviceusage.googleapis.com",
+    "container.googleapis.com",
+    "redis.googleapis.com",
+    "run.googleapis.com",
+    "cloudtasks.googleapis.com"
+  ]
+}

--- a/examples/service_account/README.MD
+++ b/examples/service_account/README.MD
@@ -7,7 +7,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.78.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.19.0 |
 
 ## Modules
 
@@ -17,22 +17,24 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google_folder_iam_member.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
 | [google_project_iam_member.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_service_account.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_iam_member.sa_token_creator_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_current_user"></a> [current\_user](#input\_current\_user) | Your user principal to add to terraform service account. Can be retrieved via `gcloud config get-value account` | `string` | n/a | yes |
 | <a name="input_folder"></a> [folder](#input\_folder) | The folder ID to grant the IAM roles to service account in. | `string` | `null` | no |
-| <a name="input_folder_collection_roles"></a> [folder\_collection\_roles](#input\_folder\_collection\_roles) | A list of IAM roles to give to the service account for folder collection.  Note that permissions are broad and this account should only be used to set up collection intially and not for anything else. | `set(string)` | <pre>[<br>  "roles/browser",<br>  "roles/cloudasset.owner",<br>  "roles/cloudfunctions.admin",<br>  "roles/cloudscheduler.admin",<br>  "roles/cloudtasks.admin",<br>  "roles/iam.serviceAccountCreator",<br>  "roles/iam.serviceAccountDeleter",<br>  "roles/iam.serviceAccountKeyAdmin",<br>  "roles/iam.serviceAccountTokenCreator",<br>  "roles/iam.serviceAccountUser",<br>  "roles/logging.admin",<br>  "roles/monitoring.admin",<br>  "roles/pubsub.admin",<br>  "roles/resourcemanager.folderAdmin",<br>  "roles/resourcemanager.projectCreator",<br>  "roles/resourcemanager.projectDeleter",<br>  "roles/resourcemanager.projectMover",<br>  "roles/serviceusage.serviceUsageAdmin",<br>  "roles/serviceusage.serviceUsageConsumer",<br>  "roles/servicemanagement.admin",<br>  "roles/storage.admin"<br>]</pre> | no |
+| <a name="input_folder_collection_roles"></a> [folder\_collection\_roles](#input\_folder\_collection\_roles) | A list of IAM roles to give to the service account for folder collection.  Note that permissions are broad and this account should only be used to set up collection intially and not for anything else. | `set(string)` | <pre>[<br>  "roles/browser",<br>  "roles/cloudasset.owner",<br>  "roles/cloudfunctions.admin",<br>  "roles/cloudscheduler.admin",<br>  "roles/cloudtasks.admin",<br>  "roles/cloudtasks.queueAdmin",<br>  "roles/iam.serviceAccountCreator",<br>  "roles/iam.serviceAccountDeleter",<br>  "roles/iam.serviceAccountKeyAdmin",<br>  "roles/iam.serviceAccountTokenCreator",<br>  "roles/iam.serviceAccountUser",<br>  "roles/logging.admin",<br>  "roles/monitoring.admin",<br>  "roles/pubsub.admin",<br>  "roles/resourcemanager.folderAdmin",<br>  "roles/serviceusage.serviceUsageAdmin",<br>  "roles/serviceusage.serviceUsageConsumer",<br>  "roles/servicemanagement.admin",<br>  "roles/storage.admin"<br>]</pre> | no |
 | <a name="input_project"></a> [project](#input\_project) | The project ID to create the service account in.  For project collection, this will also assign the IAM roles to the account in the project. | `string` | n/a | yes |
-| <a name="input_project_collection_roles"></a> [project\_collection\_roles](#input\_project\_collection\_roles) | A list of IAM roles to give to the service account.  Note that permissions are broad and this account should only be used to set up collection intially and not for anything else. | `set(string)` | <pre>[<br>  "roles/browser",<br>  "roles/cloudasset.owner",<br>  "roles/cloudfunctions.admin",<br>  "roles/cloudscheduler.admin",<br>  "roles/cloudtasks.admin",<br>  "roles/iam.serviceAccountCreator",<br>  "roles/iam.serviceAccountDeleter",<br>  "roles/iam.serviceAccountKeyAdmin",<br>  "roles/iam.serviceAccountTokenCreator",<br>  "roles/iam.serviceAccountUser",<br>  "roles/logging.admin",<br>  "roles/monitoring.admin",<br>  "roles/pubsub.admin",<br>  "roles/resourcemanager.projectIamAdmin",<br>  "roles/serviceusage.serviceUsageAdmin",<br>  "roles/serviceusage.serviceUsageConsumer",<br>  "roles/servicemanagement.admin",<br>  "roles/storage.admin"<br>]</pre> | no |
+| <a name="input_project_collection_roles"></a> [project\_collection\_roles](#input\_project\_collection\_roles) | A list of IAM roles to give to the service account.  Note that permissions are broad and this account should only be used to set up collection intially and not for anything else. | `set(string)` | <pre>[<br>  "roles/browser",<br>  "roles/cloudasset.owner",<br>  "roles/cloudfunctions.admin",<br>  "roles/cloudscheduler.admin",<br>  "roles/cloudtasks.admin",<br>  "roles/cloudtasks.queueAdmin",<br>  "roles/cloudfunctions.admin",<br>  "roles/iam.serviceAccountCreator",<br>  "roles/iam.serviceAccountDeleter",<br>  "roles/iam.serviceAccountKeyAdmin",<br>  "roles/iam.serviceAccountTokenCreator",<br>  "roles/iam.serviceAccountUser",<br>  "roles/logging.admin",<br>  "roles/monitoring.admin",<br>  "roles/pubsub.admin",<br>  "roles/resourcemanager.projectIamAdmin",<br>  "roles/serviceusage.serviceUsageAdmin",<br>  "roles/serviceusage.serviceUsageConsumer",<br>  "roles/servicemanagement.admin",<br>  "roles/storage.admin"<br>]</pre> | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | <a name="output_service_account"></a> [service\_account](#output\_service\_account) | n/a |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | n/a |
 <!-- END_TF_DOCS -->

--- a/examples/service_account/main.tf
+++ b/examples/service_account/main.tf
@@ -1,8 +1,15 @@
 resource "google_service_account" "this" {
 
-  account_id  = "observe-collect"
+  account_id  = "terraform-observe-collect-sa"
   description = "Used to set up collection"
   project     = var.project
+}
+
+# Grant yourself the Service Token Creator Role
+resource "google_service_account_iam_member" "sa_token_creator_role" {
+  service_account_id = google_service_account.this.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "user:${var.current_user}"
 }
 
 ###############
@@ -10,16 +17,18 @@ resource "google_service_account" "this" {
 # Uncomment the first section for a service account that can deploy to a project
 # and uncomment the second section for folder collection.  If you are deploying to
 # a folder, you need to add the folder id to the service_account.auto.tfvars file as well.
-#
+# 
+# The default is to use a project 
+
 ################
 
-# resource "google_project_iam_member" "this" {
-#   for_each = var.project_collection_roles
+resource "google_project_iam_member" "this" {
+  for_each = var.project_collection_roles
 
-#   project = var.project
-#   role    = each.key
-#   member  = "serviceAccount:${google_service_account.this.email}"
-# }
+  project = var.project
+  role    = each.key
+  member  = "serviceAccount:${google_service_account.this.email}"
+}
 
 # resource "google_folder_iam_member" "this" {
 #   for_each = var.folder_collection_roles
@@ -28,3 +37,4 @@ resource "google_service_account" "this" {
 #   role    = each.key
 #   member  = "serviceAccount:${google_service_account.this.email}"
 # }
+

--- a/examples/service_account/output.tf
+++ b/examples/service_account/output.tf
@@ -1,3 +1,7 @@
 output "service_account" {
   value = google_service_account.this
 }
+
+output "service_account_email" {
+  value = google_service_account.this.email
+}

--- a/examples/service_account/output.tf
+++ b/examples/service_account/output.tf
@@ -1,3 +1,3 @@
 output "service_account" {
-   value = google_service_account.this
+  value = google_service_account.this
 }

--- a/examples/service_account/service_account.auto.tfvars
+++ b/examples/service_account/service_account.auto.tfvars
@@ -1,3 +1,3 @@
-project = "my_project_id" 
+project = "my_project_id"
 # folder ="my_folder_id" #uncomment for folder collection
 current_user = "my-principal-email@gmail.com" #Get via gcloud config get-value account 

--- a/examples/service_account/service_account.auto.tfvars
+++ b/examples/service_account/service_account.auto.tfvars
@@ -1,2 +1,3 @@
-project = "my_project_id"
+project = "my_project_id" 
 # folder ="my_folder_id" #uncomment for folder collection
+current_user = "my-principal-email@gmail.com" #Get via gcloud config get-value account 

--- a/examples/service_account/variables.tf
+++ b/examples/service_account/variables.tf
@@ -15,8 +15,8 @@ variable "folder" {
 }
 
 variable "current_user" {
-  type = string
-  description = "value"
+  type        = string
+  description = "Your user principal email to add to terraform service account. Can be retrieved via `gcloud config get-value account`"
 }
 
 variable "project_collection_roles" {

--- a/examples/service_account/variables.tf
+++ b/examples/service_account/variables.tf
@@ -1,3 +1,24 @@
+
+variable "project" {
+  type        = string
+  description = <<-EOF
+    The project ID to create the service account in.  For project collection, this will also assign the IAM roles to the account in the project.
+    EOF
+}
+
+variable "folder" {
+  type        = string
+  description = <<-EOF
+    The folder ID to grant the IAM roles to service account in.
+    EOF
+  default     = null
+}
+
+variable "current_user" {
+  type = string
+  description = "value"
+}
+
 variable "project_collection_roles" {
   description = <<-EOF
     A list of IAM roles to give to the service account.  Note that permissions are broad and this account should only be used to set up collection intially and not for anything else.
@@ -10,6 +31,8 @@ variable "project_collection_roles" {
     "roles/cloudfunctions.admin",
     "roles/cloudscheduler.admin",
     "roles/cloudtasks.admin",
+    "roles/cloudtasks.queueAdmin",
+    "roles/cloudfunctions.admin",
     "roles/iam.serviceAccountCreator",
     "roles/iam.serviceAccountDeleter",
     "roles/iam.serviceAccountKeyAdmin",
@@ -38,6 +61,7 @@ variable "folder_collection_roles" {
     "roles/cloudfunctions.admin",
     "roles/cloudscheduler.admin",
     "roles/cloudtasks.admin",
+    "roles/cloudtasks.queueAdmin",
     "roles/iam.serviceAccountCreator",
     "roles/iam.serviceAccountDeleter",
     "roles/iam.serviceAccountKeyAdmin",
@@ -47,27 +71,9 @@ variable "folder_collection_roles" {
     "roles/monitoring.admin",
     "roles/pubsub.admin",
     "roles/resourcemanager.folderAdmin",
-    "roles/resourcemanager.projectCreator",
-    "roles/resourcemanager.projectDeleter",
-    "roles/resourcemanager.projectMover",
     "roles/serviceusage.serviceUsageAdmin",
     "roles/serviceusage.serviceUsageConsumer",
     "roles/servicemanagement.admin",
     "roles/storage.admin",
   ]
-}
-
-variable "project" {
-    type = string
-    description = <<-EOF
-    The project ID to create the service account in.  For project collection, this will also assign the IAM roles to the account in the project.
-    EOF
-}
-
-variable "folder" {
-    type = string
-    description = <<-EOF
-    The folder ID to grant the IAM roles to service account in.
-    EOF
-    default = null
 }


### PR DESCRIPTION
## What does this PR do?

 - Updates `service_account` creation
 - Adds API Enablement modules

## Motivation
- We had a few customers wanting automation for the tedious process of service account/apis that is highly error prone when done manually
- This allows doing so via terraform

## Testing

Tested in new project `test-svc-account-automation` for following:
- Enabled APIs via `api_module`
- Created SVC Acount via `service_account` module 
- Create Observe Collection via `project` module 
- Used output to ensure data is flowing into Observe properly 