### PR TITLE
fix logging exclusinos and add asset switcher

### DIFF
--- a/asset.tf
+++ b/asset.tf
@@ -3,7 +3,7 @@
 # particular folder.
 
 resource "google_cloud_asset_folder_feed" "folder_feed" {
-  count           = local.resource_type == "folders" ? 1 : 0
+  count           = local.resource_type == "folders" && var.enable_asset_feed ? 1 : 0
   billing_project = var.project_id
   folder          = data.google_folder.this[0].folder_id
   feed_id         = "${local.name}-asset-updates"
@@ -22,7 +22,7 @@ resource "google_cloud_asset_folder_feed" "folder_feed" {
 
 # Create a feed that sends notifications about network resource updates.
 resource "google_cloud_asset_project_feed" "project_feed" {
-  count        = local.resource_type == "projects" ? 1 : 0
+  count        = local.resource_type == "projects" && var.enable_asset_feed ? 1 : 0
   project      = var.project_id
   feed_id      = "${local.name}-asset-updates"
   content_type = "RESOURCE"
@@ -35,3 +35,4 @@ resource "google_cloud_asset_project_feed" "project_feed" {
     }
   }
 }
+

--- a/main.tf
+++ b/main.tf
@@ -54,10 +54,10 @@ resource "google_logging_project_sink" "this" {
   dynamic "exclusions" {
     for_each = var.logging_exclusions
     content {
-      name        = exclusions.name
-      description = exclusions.description
-      filter      = exclusions.filter
-      disabled    = exclusions.disabled
+      name        = exclusions.value.name
+      description = exclusions.value.description
+      filter      = exclusions.value.filter
+      disabled    = exclusions.value.disabled
     }
   }
 }
@@ -76,10 +76,10 @@ resource "google_logging_folder_sink" "this" {
   dynamic "exclusions" {
     for_each = var.logging_exclusions
     content {
-      name        = exclusions.name
-      description = exclusions.description
-      filter      = exclusions.filter
-      disabled    = exclusions.disabled
+      name        = exclusions.value.name
+      description = exclusions.value.description
+      filter      = exclusions.value.filter
+      disabled    = exclusions.value.disabled
     }
   }
 }
@@ -97,10 +97,10 @@ resource "google_logging_organization_sink" "this" {
   dynamic "exclusions" {
     for_each = var.logging_exclusions
     content {
-      name        = exclusions.name
-      description = exclusions.description
-      filter      = exclusions.filter
-      disabled    = exclusions.disabled
+      name        = exclusions.value.name
+      description = exclusions.value.description
+      filter      = exclusions.value.filter
+      disabled    = exclusions.value.disabled
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -125,6 +125,12 @@ variable "enable_function" {
   default     = true
 }
 
+variable "enable_asset_feed" {
+  description = "Whether to enable the Cloud asset inventory feed"
+  type        = bool
+  default     = true
+}
+
 variable "folder_include_children" {
   description = "Whether to include all children Projects of a Folder when collecting logs"
   type        = bool
@@ -240,3 +246,4 @@ variable "cloud_function_debug_level" {
   type        = string
   default     = "WARNING"
 }
+


### PR DESCRIPTION
## What does this PR do?

1. Looks like you don't have tests for log exclusion logic. There is a missing part in for_each loop
2. Add a switcher for GCP assets inventory

## Motivation

I want to add exclusion in my logs sync
And I don't want to enable asset inventory in my projects

## Testing

TF 1.9.3 deploy my infra with forked module.