### PR TITLE
fix: updating to point at the latest version

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -140,7 +140,7 @@ variable "function_bucket" {
 variable "function_object" {
   description = "GCS object key of the Cloud Function source code zip file"
   type        = string
-  default     = "google-cloud-functions-v0.3.0.zip"
+  default     = "google-cloud-functions-latest.zip"
 }
 
 variable "function_available_memory_mb" {

--- a/variables.tf
+++ b/variables.tf
@@ -138,7 +138,7 @@ variable "function_bucket" {
 }
 
 variable "function_object" {
-  description = "GCS object key of the Cloud Function source code zip file"
+  description = "GCS object key of the Cloud Function source code zip file. Will use the latest release unless modified."
   type        = string
   default     = "google-cloud-functions-latest.zip"
 }


### PR DESCRIPTION
Users could always override if desired but will point at the latest that we have produced.

## What does this PR do?

Required - This will point at the latest version so the customer will always get the latest produced version.  If desired, they can fix to a particular version in variables. 

## Testing

Going to pull the latest version in my build to test and apply before bumping to the latest.  Mapped the source to this branch in terraform.  Functions running successfully in GCP after the updates have been deployed.
