### PR TITLE
feat: add bucket lifecycle and currency

### DIFF
--- a/function.tf
+++ b/function.tf
@@ -51,6 +51,26 @@ resource "google_storage_bucket" "this" {
   # Since the bucket is just a temporary storage for asset export objects until 
   # the function can process them, we want to implicitly delete any leftover objects
   # if Terraform plans to remove the bucket
+
+  # added for maintaining the bucket file and folder lifecycle
+  lifecycle_rule {
+    condition {
+      age = var.bucket_lifecycle_delete_days
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  lifecycle_rule {
+    condition {
+      age = var.bucket_lifecycle_abort_upload_days
+    }
+    action {
+      type = "AbortIncompleteMultipartUpload"
+    }
+  }
+
 }
 
 resource "google_storage_bucket_iam_member" "bucket_iam" {

--- a/variables.tf
+++ b/variables.tf
@@ -244,11 +244,11 @@ variable "cloud_function_debug_level" {
 variable "bucket_lifecycle_delete_days" {
   description = "The number of days to wait before Delete of temporary bucket files."
   type        = number
-  default     = 3  
+  default     = 14  
 }
 
 variable "bucket_lifecycle_abort_upload_days" {
   description = "The number of days to wait before deleting AbortIncompleteMultipartUpload."
   type        = number
-  default     = 1  
+  default     = 7  
 }

--- a/variables.tf
+++ b/variables.tf
@@ -240,3 +240,15 @@ variable "cloud_function_debug_level" {
   type        = string
   default     = "WARNING"
 }
+
+variable "bucket_lifecycle_delete_days" {
+  description = "The number of days to wait before Delete of temporary bucket files."
+  type        = number
+  default     = 3  
+}
+
+variable "bucket_lifecycle_abort_upload_days" {
+  description = "The number of days to wait before deleting AbortIncompleteMultipartUpload."
+  type        = number
+  default     = 1  
+}


### PR DESCRIPTION
## What does this PR do?

Add default bucket lifecycle rules for Deletion of old objects and cleanout of old multipart uploads.

## Motivation

Ensure that we effectively ensure that temporary files do not build up in the bucket.

## Testing

Tested this inside of internal staging environment.
